### PR TITLE
content: soften Terraform module attribution

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@
                   Migrated 2 Azure subscriptions to full Terraform management, importing 90+ resources including VMs, MySQL, storage, NSGs, and Key Vault. Achieved a zero-change plan after import, validating complete configuration parity with existing infrastructure.</p>
 
                   <p><strong>Reusable Compute Module</strong><br>
-                  Built a portable Terraform compute module using a for-each key-based pattern with tfvars-driven VM configuration per region, backed by Azure DevOps pipelines. The module was adopted by the enterprise architecture team for use in their own environments.</p>
+                  Built a portable Terraform compute module using a for-each key-based pattern with tfvars-driven VM configuration per region, backed by Azure DevOps pipelines. The module was adopted and used by other teams across the organization.</p>
 
                   <p><strong>Additional contributions:</strong></p>
                   <ul>


### PR DESCRIPTION
## Summary

- Updates one line in the Blackbaud Reusable Compute Module entry to remove the specific reference to the enterprise architecture team

🤖 Generated with [Claude Code](https://claude.com/claude-code)